### PR TITLE
Include @planning-poker/web as dependency of @planning-poker/backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "packages/*"
   ],
   "scripts": {
-    "dev": "lerna run dev --parallel --stream",
-    "build": "lerna run build --parallel --stream && yarn copy-assets",
+    "dev": "lerna run dev --scope @planning-poker/backend --include-dependencies --parallel --stream",
+    "build": "lerna run build --scope @planning-poker/backend --include-dependencies && yarn copy-assets",
     "copy-assets": "cpy 'packages/web/build/**/*' packages/backend/build/public",
     "binary": "pkg .",
     "docker-image": "docker build -t planning-poker:latest .",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "express": "^4.18.2",
     "socket.io": "^4.7.2",
-    "@planning-poker/shared": "*"
+    "@planning-poker/shared": "*",
+    "@planning-poker/web": "*"
   },
   "devDependencies": {
     "@types/node": "^16.18.67",


### PR DESCRIPTION
Link dependency of backend, or whole application, to web.  

Now we can use features of lerna like "--include-dependencies" to prevent too many runs in future, created by adding for example multiple packages.

In future we should migrate to nx to gain more features like caching, dependency graph and so on.  
Also we can transfer then the "scripts" section to another file like "project.json" of nx or so.